### PR TITLE
fix: rename recessor to predecessor, getOtherVertex

### DIFF
--- a/Dijstra-Algorithm-Project-INF21.iml
+++ b/Dijstra-Algorithm-Project-INF21.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/Dijstra-Algorithm-Project-INF21/src" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/Dijstra-Algorithm-Project-INF21/src/Model/Edge.java
+++ b/Dijstra-Algorithm-Project-INF21/src/Model/Edge.java
@@ -20,10 +20,10 @@ public class Edge implements Serializable {
 
     public Vertex getEndingVertex(){return v2;}
 
-    public Vertex getOtherVertex(Vertex vertex) throws Exception {
+    public Vertex getOtherVertex(Vertex vertex){
         if(vertex.equals(v1)){return v2;
         }else if(vertex.equals(v2)){return v1;
-        }else{throw new Exception("Invalid Vertex");}
+        }else{return null;}
     }
 
     public int getMarking(){return marking;}

--- a/Dijstra-Algorithm-Project-INF21/src/Model/Vertex.java
+++ b/Dijstra-Algorithm-Project-INF21/src/Model/Vertex.java
@@ -6,17 +6,17 @@ import java.util.Objects;
 public class Vertex implements Serializable {
     private int id;
     private int costs = 0;
-    private Vertex precessor;
+    private Vertex predecessor;
     private double lat;//Breitengrad
     private double lon;//Längengrad
     private String identifier;//Bezeichner
     private boolean junction;//anschlussstelle
 
-    public Vertex(int id, double lat, double lon, Vertex precessor, String identifier, boolean junction){
+    public Vertex(int id, double lat, double lon, Vertex predecessor, String identifier, boolean junction){
         this.id = id;
         this.lat = lat;
         this.lon = lon;
-        this.precessor =  precessor;
+        this.predecessor =  predecessor;
         this.identifier = identifier;
         this.junction = junction;
     }
@@ -24,7 +24,7 @@ public class Vertex implements Serializable {
         this.id = id;
         this.lat = lat;
         this.lon = lon;
-        this.precessor = null;
+        this.predecessor = null;
         this.identifier = null;
         this.junction = false;
     }
@@ -35,7 +35,7 @@ public class Vertex implements Serializable {
 
     public int getCosts(){return costs;}
 
-    public Vertex getPrecessor(){return precessor;}
+    public Vertex getPredecessor(){return predecessor;}
 
     public double getLat(){return lat;}
 


### PR DESCRIPTION
return null instead of throwing error at getOtherVertex at Edge